### PR TITLE
Made Document.file_name unique

### DIFF
--- a/djweb/dj_comp_hist/models.py
+++ b/djweb/dj_comp_hist/models.py
@@ -103,7 +103,7 @@ class Document(models.Model):
     cced_organization = models.ManyToManyField(Organization, related_name='cced_organization',
                                                blank=True)
     notes = models.CharField(max_length=191, blank=True)
-    file_name = models.CharField(max_length=191, blank=True)
+    file_name = models.CharField(max_length=191, blank=True, unique=True)
 
     def __str__(self):
         return self.title


### PR DESCRIPTION
Document.file_name uniquely identifies a Document. We can use this to prevent duplicates when running populate_from_metadata multiple times w/o flushing the db before.