### PR TITLE
Fixed: index didn't render because index.jinja had been renamed index_arch.jinja

### DIFF
--- a/djweb/dj_comp_hist/views.py
+++ b/djweb/dj_comp_hist/views.py
@@ -9,7 +9,7 @@ from django.http import HttpResponse
 
 
 def index(request):
-    return render(request, 'index.jinja2')
+    return render(request, 'index_arch.jinja2')
 
 
 def person(request, person_id):


### PR DESCRIPTION
@elenaboal : was there a reason for the change?