### PR TITLE
advanced search link in navbar 

### DIFF
--- a/djweb/templates/base.jinja2
+++ b/djweb/templates/base.jinja2
@@ -50,7 +50,7 @@
                     <a class="nav-link" href="/simulations">Simulations</a>
                 </li>
                 <li class="nav-item active">
-                    <a class="nav-link" href="/dj_comp_hist/search_results">Advanced Search</a>
+                    <a class="nav-link" href="/dj_comp_hist/search_results/?q=">Advanced Search</a>
                 </li>
             </ul>
             <form class="form-inline my-2 my-lg-0" action="/dj_comp_hist/search_results">


### PR DESCRIPTION
directs to search_results instead of displaying error page (temp fix until we decide on what we want to do with the advanced search link or to have it at all)