### PR TITLE
Minor change to .gitignore for js dev

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -146,3 +146,6 @@ computation_hist/scratch.py
 # except txt files
 computation_hist/data/processed_pdfs/**/*.pdf
 computation_hist/data/processed_pdfs/**/*.png
+
+node_modules/
+package-lock.json


### PR DESCRIPTION
node_modules and package-lock.json should rarely be committed to a repository (it's like the virtual-env for javascript)