### PR TITLE
Fixed full text search error

### DIFF
--- a/djweb/dj_comp_hist/views.py
+++ b/djweb/dj_comp_hist/views.py
@@ -237,7 +237,9 @@ def advanced_search(request):
     try:
         phrase = request.GET['contents']
         if phrase != '':
-            doc_objs = Document.objects.raw(f'SELECT * from doc_fts WHERE text MATCH "{phrase}"')
+            raw_docs = Document.objects.raw(f'SELECT * from doc_fts WHERE text MATCH "{phrase}"')
+            doc_ids = [doc.id for doc in raw_docs]
+            doc_objs = doc_objs.filter(id__in=doc_ids)
 
     except:
         print("Error getting phrase")


### PR DESCRIPTION
The previous implementation of  the full text search returned a RawQuerySet, which doesn't work with the QuerySet that the other parts of the search expects. This commit fixes the issue (i.e. the full text search returns a query set).
Branch can be deleted after merge.