### PR TITLE
Travis setup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,14 @@
+language: python
+python:
+  - "3.6"
+
+before_install:
+  - export DJANGO_SETTINGS_MODULE='config.settings'
+
+install:
+  - pip install -r requirements.txt
+  - python manage.py migrate
+
+script:
+  - echo "from utilities.metadata_parser import populate_from_metadata; populate_from_metadata" | python manage.py shell
+  - python manage.py runserver

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,5 +10,5 @@ install:
   - python manage.py migrate
 
 script:
-  - echo "from utilities.metadata_parser import populate_from_metadata; populate_from_metadata" | python manage.py shell
-  - python manage.py runserver
+  - python manage.py populate_from_metadata
+    # - python manage.py runserver

--- a/apps/archives/management/commands/populate_from_metadata.py
+++ b/apps/archives/management/commands/populate_from_metadata.py
@@ -1,0 +1,7 @@
+from django.core.management.base import BaseCommand
+
+from utilities.metadata_parser import populate_from_metadata
+
+class Command(BaseCommand):
+    def handle(self, *args, **options):
+        populate_from_metadata()


### PR DESCRIPTION
- Adds .travis.yml, which just installs the site and checks that populate_from_metadata runs without crashing
- make populate_from_metadata into a management command, so you can `python manage.py populate_from_metadata`