### PR TITLE
Travis sqlite3 fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,6 @@ python:
   - "3.6"
 
 before_install:
-  - sudo apt-get update
-  - sudo apt-get install sqlite3=3.8.3
   - export DJANGO_SETTINGS_MODULE='config.settings'
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,10 @@
 language: python
 python:
-  - "3.7"
+  - "3.6"
 
 before_install:
+  - sudo apt-get update
+  - sudo apt-get install sqlite3=3.8.3
   - export DJANGO_SETTINGS_MODULE='config.settings'
 
 install:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 dh_testers
-django>=2.1
+django=2.1
 django_jinja>=2.4.1
 google-api-python-client
 ipython

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 dh_testers
-django=2.1
+django==2.1
 django_jinja>=2.4.1
 google-api-python-client
 ipython


### PR DESCRIPTION
Latest version of Django does not play nice with sqlite3 < 3.8.2 (https://code.djangoproject.com/ticket/30055) -- but Travis comes by default with 3.8.2.

We resolve this here by coercing the installation of Django 2.1, so we don't get the version that chokes on 3.8.1. This is __not__ a good long-term solution.