### PR TITLE
Add message to advanced_search.jinja2 when no results

### DIFF
--- a/templates/archives/advanced_search.jinja2
+++ b/templates/archives/advanced_search.jinja2
@@ -125,6 +125,10 @@
                     </table>
                 </div>
             {% endfor %}
+
+            {% if not results %}
+                <h3>There are no documents that match your search.</h3>
+            {% endif %}
         </div>
         </div>
         </div>


### PR DESCRIPTION
Displays "there are no documents that match your search" instead of nothing if there are no results