### PR TITLE
Travis branch config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ branches:
   - master
   - /.*(?i:travis).*$/ # branch name contains case-insensitive substring travis
 
-
 language: python
 python:
   - "3.6"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,8 @@
+branches:
+  only:
+  - master
+  - /.*(?i:travis).*$/ # branch name contains case-insensitive substring travis
+
 language: python
 python:
   - "3.6"

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ branches:
   - master
   - /.*(?i:travis).*$/ # branch name contains case-insensitive substring travis
 
+
 language: python
 python:
   - "3.6"


### PR DESCRIPTION
We no longer run Travis on all pushed branches: only pushes to master, PRs, and branches whose name contains the substring `travis` (case insensitive).