### PR TITLE
Rudimentary Duplicate Name Checking

### DIFF
--- a/utilities/metadata_parser.py
+++ b/utilities/metadata_parser.py
@@ -334,6 +334,7 @@ def interpret_person_organization(field, item_organization, item_person, new_doc
                         first_name += name + " "
                 first_name = first_name.strip()
 
+            # check for duplicate
             if last_name != '':
                 if last_name not in names_so_far:
                     if first_name != '':


### PR DESCRIPTION
Changes to metadata_parser:

Automatically standardizes whitespace and periods after initials in names when populating metadata.  

Checks for duplicates caused by only having first initial instead of full first name and gives a warning, so the issue can be corrected manually with Ctrl-F in the spreadsheet with human discretion.  

This won't catch everything but is a decent first step to resolving #113 .

@angcast 