### PR TITLE
fix footer height and position

### DIFF
--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -10,14 +10,16 @@ body {
 }
 
 .footer {
-    position: relative;
-    top: 300px;
+    position: absolute;
     bottom: 0;
     width: 100%;
 }
 
 .footer-img {
      height: 80px;
+     max-height: 10vh !important;
+     max-width: 20vw;
+     object-fit: contain;
 }
 
 .image-container {

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -17,7 +17,7 @@ body {
 
 .footer-img {
      height: 80px;
-     max-height: 10vh !important;
+     max-height: 10vh;
      max-width: 20vw;
      object-fit: contain;
 }

--- a/templates/base.jinja2
+++ b/templates/base.jinja2
@@ -88,23 +88,23 @@
 <!-- js -->
 {% block footer %}
 <footer class="footer bg-white text-dark text-center">
-    <div class="container">
+    <div class="container-fluid">
         <div class="row">
-            <div class="col-lg-4 py-3">
+            <div class="col-4 py-3">
                 <a href="https://digitalhumanities.mit.edu/">
                     <img src="{{ static('img/dh_logo.png') }}"
                          class='footer-img'
                          alt='Digital Humanities at MIT Logo'/>
                 </a>
             </div>
-            <div class="col-lg-4 py-3">
+            <div class="col-4 py-3">
                 <a href="https://www.mit.edu/">
                     <img src="{{ static('img/mit_logo.svg') }}"
                          class='footer-img'
                          alt='MIT Logo'/>
                 </a>
             </div>
-            <div class="col-lg-4 py-3">
+            <div class="col-4 py-3">
                 <a href="https://www.mellon.org/">
                     <img src="{{ static('img/mellon_logo.svg') }}"
                          class='footer-img'


### PR DESCRIPTION
Fixes the footer so the images resize nicely and we don't take over the whole screen.

@Mayowa99 — could you please check out what I've done here? Your original solution was good for the case of a small sized screen, but because of the relative positioning and high top, you'd end up with the footer bar up above the bottom of the viewport in some situations. This new version keeps it fixed absolutely to the bottom, but also keeps it from stacking and just shrinks the images instead.