### PR TITLE
Getting rid of redundant <h1> tags

### DIFF
--- a/templates/archives/box.jinja2
+++ b/templates/archives/box.jinja2
@@ -4,7 +4,7 @@ F
 {% block title %} Box {{ box_obj.number }} {% endblock %}
 
 {% block header %}
-<h1>Box number {{box_obj.number}}</h1>
+Box number {{box_obj.number}}
 {% endblock %}
 
 {% block content %}

--- a/templates/archives/browse.jinja2
+++ b/templates/archives/browse.jinja2
@@ -5,7 +5,7 @@
 {% block title %} Computational History {% endblock %}
 
 {% block header %}
-    <h1>Welcome to the Computation History Project</h1>
+    Welcome to the Computation History Project
     <br><br>
 {% endblock %}
 

--- a/templates/archives/doc.jinja2
+++ b/templates/archives/doc.jinja2
@@ -8,7 +8,7 @@
 
 {% block header %}
 
-    <h1>{{ doc_obj }}</h1>
+    {{ doc_obj }}
 
 {% endblock %}
 

--- a/templates/archives/folder.jinja2
+++ b/templates/archives/folder.jinja2
@@ -4,8 +4,8 @@
 {% block title %} {{ folder_obj.full }} {% endblock %}
 
 {% block header %}
-<h1>{{folder_obj.full}}</h1>
-<h2>Folder number {{folder_obj.number}}</h2>
+    {{folder_obj.full}}
+    <h2>Folder number {{folder_obj.number}}</h2>
 {% endblock %}
 
 {% block content %}

--- a/templates/archives/list.jinja2
+++ b/templates/archives/list.jinja2
@@ -19,9 +19,9 @@
 
 {% block header %}
     {% if model_str == 'doc' %}
-        <h1>Here are the list of documents that match your search</h1>
+        Here are the list of documents that match your search
     {% else %}
-        <h1>You're looking at every {{ model_str }}</h1>
+        You're looking at every {{ model_str }}
     {% endif %}
 {% endblock %}
 

--- a/templates/archives/organization.jinja2
+++ b/templates/archives/organization.jinja2
@@ -3,9 +3,7 @@
 {% block title %} {{ org_obj }} {% endblock %}
 
 {% block header %}
-    <h1>
-        {{org_obj}}
-    </h1>
+    {{org_obj}}
 {% endblock %}
 
 {% block content %}

--- a/templates/archives/person.jinja2
+++ b/templates/archives/person.jinja2
@@ -3,9 +3,7 @@
 {% block title %} {{person_obj.first}} {{ person_obj.last }} {% endblock %}
 
 {% block header %}
-    <h1>
-        {{person_obj.first}} {{person_obj.last}}
-    </h1>
+    {{person_obj.first}} {{person_obj.last}}
 {% endblock %}
 
 {% block content %}

--- a/templates/base.jinja2
+++ b/templates/base.jinja2
@@ -66,8 +66,6 @@
             </form>
         </div>
     </nav>
-
-
 <main role="main" class="container mb-4">
     <div class="starter-template">
         <h1 >{% block header %}{% endblock %}</h1>

--- a/templates/simulations/index.jinja2
+++ b/templates/simulations/index.jinja2
@@ -3,7 +3,7 @@
 {% block title %} Computational History {% endblock %}
 
 {% block header %}
-    <h1>Welcome to our Simulations</h1>
+    Welcome to our Simulations
     <br><br>
 {% endblock %}
 

--- a/z_unused/page.jinja2
+++ b/z_unused/page.jinja2
@@ -4,7 +4,7 @@
 
 {% block header %}
 
-    <h1>You're looking at {{ page_obj }}</h1>
+    You're looking at {{ page_obj }}
 
 {% endblock %}
 


### PR DESCRIPTION
```
{% block header %}
<h1>
"a page name"
</h1>
{% endblock %}
```
This is redundant so I got rid of occurances of this.