### PR TITLE
Switches order in document display

### DIFF
--- a/templates/archives/advanced_search.jinja2
+++ b/templates/archives/advanced_search.jinja2
@@ -99,13 +99,11 @@
                 <div class="col-lg-9 col-md-9 col-sm-12">
 
                 {% for doc in results %}
+
                     <div class="doc_result">
                         <h4><a href="{{ doc.url }}">{{ doc.title }}</a></h4>
                         <table class="doc_result_left_table">
                             <tbody>
-                                <tr>
-                                    <td class="td_heading">Date : </td><td>{{ doc.date }}</td>
-                                </tr>
 
                                 {% for author in doc.get_person_list('authors') %}
                                     <tr>
@@ -118,13 +116,7 @@
                                         <td>{{ author.name.replace("_"," ")}}</td>
                                     </tr>
                                 {% endfor %}
-                            </tbody>
-                        </table>
-                        <table class="doc_result_right_table">
-                            <tbody>
-                                <tr>
-                                    <td class="td_heading">Folder : </td><td>{{ doc.folder }}</td>
-                                </tr>
+
                                 {% for recipient in doc.get_person_list('recipients') %}
                                     <tr>
                                         <td class="td_heading">
@@ -136,6 +128,20 @@
                                         <td>{{ recipient.name.replace("_"," ")}}</td>
                                     </tr>
                                 {% endfor %}
+
+                            </tbody>
+                        </table>
+                        <table class="doc_result_right_table">
+                            <tbody>
+
+                                <tr>
+                                    <td class="td_heading">Folder : </td><td>{{ doc.folder }}</td>
+                                </tr>
+
+                                <tr>
+                                    <td class="td_heading">Date : </td><td>{{ doc.date }}</td>
+                                </tr>
+
                             </tbody>
                         </table>
                     </div>


### PR DESCRIPTION
When we have the name of the different documents displayed, the information underneath it would be better organized if we had Author and Recipient in the same column. Also, Folder and Date in the same column. Author and Recipient is a pair and so is Folder and Date.

Helps solve some of the problems in #310