### PR TITLE
Reference documents by slug only, not by PK

### DIFF
--- a/apps/archives/urls.py
+++ b/apps/archives/urls.py
@@ -5,7 +5,6 @@ from . import views
 urlpatterns = [
     path('', views.index, name='index'),
     path(r'person/<int:person_id>', views.person, name='person'),
-    path('doc/<int:doc_id>', views.doc, name='document'),
     path('doc/<str:slug>', views.doc, name='document'),
     path('box/<int:box_id>', views.box, name='box'),
     path('folder/<int:folder_id>', views.folder, name='folder'),

--- a/templates/archives/folder.jinja2
+++ b/templates/archives/folder.jinja2
@@ -22,7 +22,7 @@
         <tr>
           <th scope="row">{{ loop.index }} </th>
 
-          <td><a href = "/archives/doc/{{item.pk}}">{{ item }}</a></td>
+          <td><a href = "/archives/doc/{{ item.slug }}">{{ item }}</a></td>
         </tr>
       {% endfor %}
       </tbody>

--- a/templates/archives/organization.jinja2
+++ b/templates/archives/organization.jinja2
@@ -24,7 +24,7 @@
                 <tr>
                     <th scope="row">{{ loop.index }} </th>
 
-                    <td><a href="/archives/doc/{{ item.pk }}">{{ item }}</a></td>
+                    <td><a href="/archives/doc/{{ item.slug }}">{{ item }}</a></td>
                 </tr>
             {% endfor %}
             </tbody>
@@ -47,7 +47,7 @@
                 <tr>
                     <th scope="row">{{ item.id }} </th>
 
-                    <td><a href="/archives/doc/{{ item.pk }}">{{ item }}</a></td>
+                    <td><a href="/archives/doc/{{ item.slug }}">{{ item }}</a></td>
                 </tr>
             {% endfor %}
             </tbody>
@@ -70,7 +70,7 @@
                 <tr>
                     <th scope="row">{{ item.id }} </th>
 
-                    <td><a href="/archives/doc/{{ item.pk }}">{{ item }}</a></td>
+                    <td><a href="/archives/doc/{{ item.slug }}">{{ item }}</a></td>
                 </tr>
             {% endfor %}
             </tbody>

--- a/templates/archives/person.jinja2
+++ b/templates/archives/person.jinja2
@@ -24,7 +24,7 @@
                 <tr>
                     <th scope="row">{{ loop.index }} </th>
 
-                    <td><a href="/archives/doc/{{ item.pk }}">{{ item }}</a></td>
+                    <td><a href="/archives/doc/{{ item.slug }}">{{ item }}</a></td>
                 </tr>
             {% endfor %}
             </tbody>
@@ -47,7 +47,7 @@
                 <tr>
                     <th scope="row">{{ item.id }} </th>
 
-                    <td><a href="/archives/doc/{{ item.pk }}">{{ item }}</a></td>
+                    <td><a href="/archives/doc/{{ item.slug }}">{{ item }}</a></td>
                 </tr>
             {% endfor %}
             </tbody>
@@ -70,7 +70,7 @@
                 <tr>
                     <th scope="row">{{ item.id }} </th>
 
-                    <td><a href="/archives/doc/{{ item.pk }}">{{ item }}</a></td>
+                    <td><a href="/archives/doc/{{ item.slug }}">{{ item }}</a></td>
                 </tr>
             {% endfor %}
             </tbody>

--- a/templates/archives/search_results.jinja2
+++ b/templates/archives/search_results.jinja2
@@ -37,7 +37,7 @@
         <a class="anchor" id="doc"></a>
         <h3 id="document_search_anchor">Documents that match your search</h3>
         {% for item in document_objs %}
-            <a href="/archives/doc/{{ item.pk }}">{{ item.title }}</a>
+            <a href="/archives/doc/{{ item.slug }}">{{ item.title }}</a>
             <br>
         {% endfor %}
     {% endif %}

--- a/templates/archives/stories/women_in_symbols.jinja2
+++ b/templates/archives/stories/women_in_symbols.jinja2
@@ -28,12 +28,9 @@ Women in Symbols
         This trend is also present in scholarly manuscripts, as shown in <i>#ThanksForTyping Spotlights Unnamed Women In Literary Acknowledgments</i>, an NPR article discussing the female labor behind many scholarly publications.
         This article provides evidence of academics’ wives typing up manuscripts and doing research they were often unnamed for, being credited frequently as simple “my wife,” parallel to the secretary being recognized solely by initials in external communications.</p>
 
-<a href="/archives/doc/553">File with Edna Verzuh's and Nanny B.'s notes</a>
-    <p></p>
-    <a href="/archives/doc/552">Memo to Laura</a>
-    <p></p>
-    <a href="/archives/doc/551">Final note to Frank Verzuh</a>
-    <p></p>
-    <a href="https://www.npr.org/2017/03/30/521931310/-thanksfortyping-spotlights-unnamed-women
-    -in-literary-acknowledgements"><i>#ThanksForTyping Spotlights Unnamed Women In Literary Acknowledgments</i></a>
+    <p><a href="/archives/doc/1_15_cc_equip_16">File with Edna Verzuh's and Nanny B.'s notes</a></p>
+    <p><a href="/archives/doc/1_15_cc_equip_15">Memo to Laura</a></p>
+    <p><a href="/archives/doc/1_15_cc_equip_14">Final note to Frank Verzuh</a></p>
+    <p><a href="https://www.npr.org/2017/03/30/521931310/-thanksfortyping-spotlights-unnamed-women
+    -in-literary-acknowledgements"><i>#ThanksForTyping Spotlights Unnamed Women In Literary Acknowledgments</i></a></p>
 {% endblock %}


### PR DESCRIPTION
This PR removes references to documents by PK and the associated urlpattern. Moving forward, we only reference documents by slug, as those will persist, whereas PKs might change depending on the import process from our metadata spreadsheet to the database.

@mgallegos3015 — I've requested your review, as yours was the one story where I replaced existing PK references to docs with slugs. Could you double check that the links in your story are still correct? I'm going to go ahead and merge in, but let me know if there's a problem there.