### PR TITLE
add default ordering to some archive models

### DIFF
--- a/apps/archives/models.py
+++ b/apps/archives/models.py
@@ -24,6 +24,9 @@ class Organization(models.Model):
     def url(self):
         return f'/archives/organization/{self.slug}'
 
+    class Meta:
+        ordering = ['name']
+
 
 class Person(models.Model):
     first = models.CharField(max_length=191, blank=True)
@@ -59,6 +62,9 @@ class Person(models.Model):
     def url(self):
         return f'/archives/person/{self.slug}'
 
+    class Meta:
+        ordering = ['last', 'first']
+
 
 class Box(models.Model):
     number = models.IntegerField(default=0)
@@ -75,6 +81,9 @@ class Box(models.Model):
     def url(self):
         return f'/archives/box/{self.slug}'
 
+    class Meta:
+        ordering = ['number']
+
 
 class Folder(models.Model):
     name = models.CharField(max_length=191)
@@ -83,17 +92,18 @@ class Folder(models.Model):
     number = models.IntegerField(default=0)
     slug = models.SlugField(max_length=191, unique=True)
 
-
     def __str__(self):
         return self.full
 
     def __repr__(self):
         return f"<Folder {self.full} - {self.number}>"
 
-
     @property
     def url(self):
         return f'/archives/folder/{self.slug}'
+
+    class Meta:
+        ordering = ['full']
 
 
 class Document(models.Model):

--- a/apps/archives/views.py
+++ b/apps/archives/views.py
@@ -153,16 +153,12 @@ def list_obj(request, model_str):
     """
     if model_str == "organization":
         model_objs = get_list_or_404(Organization)
-        model_objs.sort(key=lambda x: x.name)
     elif model_str == "person":
         model_objs = get_list_or_404(Person)
-        model_objs.sort(key=lambda x: x.last)
     elif model_str == "folder":
         model_objs = get_list_or_404(Folder)
-        model_objs.sort(key=lambda x: x.full)
     elif model_str == "box":
         model_objs = get_list_or_404(Box)
-        model_objs.sort(key=lambda x: x.number)
     else:
         raise ValueError("Cannot display this model. Can only display organization, person, "
                          "folder, or box")

--- a/templates/archives/list.jinja2
+++ b/templates/archives/list.jinja2
@@ -28,7 +28,7 @@
 {% block content %}
     <br>
     <div class="starter-template">
-        {% for item in model_objs|sort(attribute='slug') %}
+        {% for item in model_objs %}
             <div class="list-group">
 {#                {% if model_str == '' %}#}
                 <a href="{{ item.url }}"


### PR DESCRIPTION
(... and remove sort filter from archives/list.jinja template, which was masking backend sorting)