### PR TITLE
add closing iframe tag for pdf viewer

### DIFF
--- a/templates/archives/doc.jinja2
+++ b/templates/archives/doc.jinja2
@@ -15,7 +15,8 @@
             <div class="row" >
                 <iframe src="{{ static('ext/pdfjs/web/viewer.html') }}?file={{ doc_pdf_url }}"
                         height="900"
-                        width="90%"/>
+                        width="90%">
+                </iframe>
             </div>
             <div class="row">
                 <!--space for bottom hyperlinks to click to neighbouring documents -->


### PR DESCRIPTION
Fixes issues with pdfjs clobbering the javascript on the documents page: it wasn't PDF.js's fault... I just forgot to close the iframe!