### PR TITLE
fix aws urls in get_file_path so that ms edge can understand them

### DIFF
--- a/apps/archives/views.py
+++ b/apps/archives/views.py
@@ -124,12 +124,13 @@ def doc(request, doc_id=None, slug=None):
     if cced_organization_objs:
         if cced_organization_objs[0].name == 'unknown':
             cced_organization_objs = None
+
     doc_pdf_url = str(get_file_path(doc_obj.folder.box.number, doc_obj.folder.number,
                                     doc_obj.folder.name, file_type='pdf', path_type='aws',
                                     doc_id=doc_obj.doc_id))
 
     prev_doc, next_doc = get_neighboring_docs(doc_obj)
-
+    
     obj_dict = {
         'doc_obj': doc_obj,
         'author_person_objs': author_person_objs,
@@ -142,6 +143,7 @@ def doc(request, doc_id=None, slug=None):
         'prev_doc': prev_doc,
         'next_doc': next_doc,
     }
+
     return render(request, 'archives/doc.jinja2', obj_dict)
 
 

--- a/templates/archives/doc.jinja2
+++ b/templates/archives/doc.jinja2
@@ -18,9 +18,6 @@
                         width="90%">
                 </iframe>
             </div>
-            <div class="row">
-                <!--space for bottom hyperlinks to click to neighbouring documents -->
-            </div>
         </div>
         <div class="col-sm-2 info_bar"  style="background-color: #343a40; color: #eeeeee;">
             <h5> About this Document: </h5>

--- a/utilities/common.py
+++ b/utilities/common.py
@@ -83,7 +83,7 @@ def get_file_path(box: int, folder: int, foldername_short: str, file_type: str,
     elif path_type == 'absolute':
         return Path(PROCESSED_PDFS_PATH, path)
     elif path_type == 'aws':
-        return Path("https://s3.amazonaws.com/comp-hist/docs/", path)
+        return 'https://s3.amazonaws.com/comp-hist/docs/' + str(PurePosixPath(path))
     else:
         raise NotImplementedError('Only path_type relative, absolute, and aws are implemented.')
 

--- a/utilities/common.py
+++ b/utilities/common.py
@@ -39,7 +39,7 @@ def get_file_path(box: int, folder: int, foldername_short: str, file_type: str,
 
     To generate an aws path, use path_type='aws'
     >>> get_file_path(1, 8, 'rockefeller', file_type='raw_pdf', path_type='aws')
-    PosixPath('https:/s3.amazonaws.com/comp-hist/docs/1_8_rockefeller/raw_pdf/1_8_rockefeller_raw.pdf')
+    'https://s3.amazonaws.com/comp-hist/docs/1_8_rockefeller/raw_pdf/1_8_rockefeller_raw.pdf'
 
     :param box: int
     :param folder: int

--- a/utilities/jinja_functions.py
+++ b/utilities/jinja_functions.py
@@ -4,14 +4,12 @@ from django_jinja import library  # @UnresolvedImport
 # functions that emulate builtins -- leave last so we are not bitten
 # pylint: disable=redefined-builtin
 
-
 @library.global_function
 def dir(obj):  # @ReservedAssignment
     """
     Super useful for debugging...
     """
     return str(builtins.dir(obj))
-
 
 @library.global_function
 def getattr(*args):  # @ReservedAssignment


### PR DESCRIPTION
Because we were using Path objects to generate aws urls for the pdfs, they were a bit malformed (single slashes instead of double), which was causing MS Edge to choke when embedding.

@Carol217 - could you double check that this works?